### PR TITLE
Fix `Trackpoint#==`

### DIFF
--- a/spec/route/track_point_spec.rb
+++ b/spec/route/track_point_spec.rb
@@ -11,7 +11,7 @@ describe 'TrackPoint' do
   end
 
   context "#==" do
-    it "should discriminate two track points with different longitude" do |member|
+    it "should discriminate two track points with different longitude" do
       one   = TrackPoint.new(1,1,1)
       other = TrackPoint.new(2,1,1)
 
@@ -25,7 +25,7 @@ describe 'TrackPoint' do
       expect(one).to_not eq(other)
     end
 
-    it "should discriminate two track points with different inclination" do
+    it "should discriminate two track points with different elevation" do
       one   = TrackPoint.new(1,1,1)
       other = TrackPoint.new(1,1,2)
 

--- a/spec/route/track_point_spec.rb
+++ b/spec/route/track_point_spec.rb
@@ -10,6 +10,36 @@ describe 'TrackPoint' do
     @googleplex = TrackPoint.new -122.0840575, 37.4219999, 6
   end
 
+  context "#==" do
+    it "should discriminate two track points with different longitude" do |member|
+      one   = TrackPoint.new(1,1,1)
+      other = TrackPoint.new(2,1,1)
+
+      expect(one).to_not eq(other)
+    end
+
+    it "should discriminate two track points with different latitude" do
+      one   = TrackPoint.new(1,1,1)
+      other = TrackPoint.new(1,2,1)
+
+      expect(one).to_not eq(other)
+    end
+
+    it "should discriminate two track points with different inclination" do
+      one   = TrackPoint.new(1,1,1)
+      other = TrackPoint.new(1,1,2)
+
+      expect(one).to_not eq(other)
+    end
+
+    it "should not discriminate two equal points" do
+      one   = TrackPoint.new(1,1,1)
+      other = TrackPoint.new(1,1,1)
+
+      expect(one).to eq(other)
+    end
+  end
+
   it 'should raise exception when longitude is tried to be set to a not numeric value' do
     expect { @googleplex.longitude = 'invalid' }.to raise_exception 'Invalid longitude'
     expect { TrackPoint.new 'invalid', 0, 0 }.to raise_exception 'Invalid longitude'

--- a/src/route/track_point.rb
+++ b/src/route/track_point.rb
@@ -17,10 +17,10 @@ class TrackPoint
   end
 
   def ==(other)
-    other.is_a? self.class and
-      @longitude == other.longitude and
-      @latitude == other.latitude and
-      @elevation == other.elevation
+    self.class  == other.class &&
+    longitude   == other.longitude &&
+    latitude    == other.latitude &&
+    elevation   == other.elevation
   end
 
   def longitude=(longitude)

--- a/src/route/track_point.rb
+++ b/src/route/track_point.rb
@@ -20,7 +20,7 @@ class TrackPoint
     other.is_a? self.class and
       @longitude == other.longitude and
       @latitude == other.latitude and
-      @elevation == elevation
+      @elevation == other.elevation
   end
 
   def longitude=(longitude)


### PR DESCRIPTION
This PR fixes a bug in `Trackpoint#==` So two different track points can be discriminated properly.

Additionally I added another commit, to express the need of replacing in the rest of the code base, the incorrect usages of control flow operators (`and`, `or`), in favour of their boolean operator counterparts (`&&`, `||`).  Please read [this](http://devblog.avdi.org/2010/08/02/using-and-and-or-in-ruby/) for context.

Also, as per the Open-Close principle, a class should be open for extension but not for modification. For that reason, I also changed in the method implementation the use of instance variables (`@longitude`, etc) for its attr_readers. The benefit is that if any class overrides the behaviour of any of the reader generated methods, it won't be needed to reimplement the `#==` method.
